### PR TITLE
ENH: run afs migration modify script on already migrated repo

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!--- Provide a general summary of the issue in the Title above -->
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Expected Behavior
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Context / environment
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+
+## Suggested Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!--- Provide a general summary of your changes in the Title above -->
+## Description
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Where Has This Been Documented?
+<!--  Include where the changes made have been documented. -->
+<!--  This can simply be  a comment in the code or updating a docstring -->
+
+<!--
+## Screenshots (if appropriate):
+-->
+
+## Pre-merge checklist
+- [ ] Code works interactively
+- [ ] Code contains descriptive docstrings, including context and API

--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,4 @@
-# Twincat ignores
-_Boot
-_Libraries
-_CompileInfo
-*.sln
-*.suo
-*~
-*.tpy
-*.bak
-*.~u
-
-# EPICS ignores
+# Built file ignores
 O.*
 archive
 autosave
@@ -17,6 +6,31 @@ bin
 build
 db
 dbd
+envPaths
+html
+include
+lib
+*.log
 
-# Vim ignores
+# Terminal editor ignores
 *.swp
+*~
+
+# IDE ignores
+*.vscode
+
+# Core dumps
+core.*
+
+# From original afs gitignore
+# Twincat ignores
+_Boot
+_Libraries
+_CompileInfo
+*.sln
+*.suo
+*.tpy
+*.bak
+*.~u
+# EPICS ignores
+# Vim ignores


### PR DESCRIPTION
This repo was already migrated off of afs long ago, but I still wanted to run the migration scripts on it to the extent that they apply.

See https://github.com/pcdshub/afs_ioc_migration/pull/1
See https://confluence.slac.stanford.edu/display/PCDS/ECS+EPICS+IOC+Github+Migration+Log