### PR TITLE
BLD: bump ads module version for bulk read workaround

### DIFF
--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -11,7 +11,7 @@ IOCADMIN_MODULE_VERSION   = R3.1.15-1.10.0
 ASYN_MODULE_VERSION       = R4.35-0.0.1
 MOTOR_MODULE_VERSION      = R6.9-ess-0.0.1
 ETHERCATMC_MODULE_VERSION = R2.1.0-0.1.2
-ADS_MODULE_VERSION        = R2.0.0-0.0.7
+ADS_MODULE_VERSION        = R2.0.0-0.0.8
 CAPUTLOG_MODULE_VERSION   = R3.7-1.0.0
 
 # ============================================================


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Include @janeliu-slac 's fixes from a few months ago here.
I should have done this a few months ago...

After this PR I can tag R0.7.0 and announce the update in the pcds slack channel.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-5005
https://jira.slac.stanford.edu/browse/ECS-5034
https://jira.slac.stanford.edu/browse/ECS-5884
https://github.com/pcdshub/twincat-ads/releases/tag/R2.0.0-0.0.8

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This works interactively using https://github.com/pcdshub/lcls-plc-example-motion.
Jane's fix still works using the built tag and @KaushikMalapati 's read-only update works too (together with pcds-5.9.1 for the pytmc tag)

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only, release notes next

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
